### PR TITLE
Feature extra adapter methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
     - emulator -avd test -no-skin -no-audio -no-window &
     - android-wait-for-emulator
     - adb shell input keyevent 82 &
-script: ./gradlew clean library:check demo:connectedCheck
+script: ./gradlew clean check demo:connectedCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: android
 env:
     global:
+        #Using the new Container-Based Infrastructure
+        - sudo: false
         # Turning off caching to avoid caching Issues
         - cache: false
         # Initiating clean Gradle output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 env:
     global:
-        #Using the new Container-Based Infrastructure
+        # Using the new Container-Based Infrastructure
         - sudo: false
         # Turning off caching to avoid caching Issues
         - cache: false
@@ -13,15 +13,9 @@ android:
     components:
         - build-tools-22.0.1
         - android-22
-        - sys-img-armeabi-v7a-android-22
         - extra-android-m2repository
         - extra-google-m2repository
         - extra-android-support
     licenses:
         - android-sdk-license-5be876d5
-before_script:
-    - echo no | android create avd --force -n test -t android-22 --abi default/armeabi-v7a
-    - emulator -avd test -no-skin -no-audio -no-window &
-    - android-wait-for-emulator
-    - adb shell input keyevent 82 &
-script: ./gradlew clean check demo:connectedCheck
+script: ./gradlew clean check

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
         - cache: false
         # Initiating clean Gradle output
         - TERM=dumb
+        # Giving even more memory to Gradle JVM
+        - GRADLE_OPTS="-Xmx2048m -XX:MaxPermSize=1024m"
 android:
     components:
         - build-tools-22.0.1

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -37,4 +37,14 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'recyclerview-v7'
     }
+
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-core:1.1'
+    testCompile 'org.hamcrest:hamcrest-library:1.1'
+    testCompile 'org.hamcrest:hamcrest-integration:1.1'
+    testCompile('org.robolectric:robolectric:3.0-rc3') {
+        exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+    }
 }

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyAdapterTest.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyAdapterTest.java
@@ -47,8 +47,8 @@ import static uk.co.ribot.easyadapterdemo.util.DataUtil.getSomePeople;
  * This test is in the demo app so it can use the layout resources defined for the PersonViewHolder
  * Ideally it should be in the library module because is testing the EasyAdapter class.
  * However in order to create an EasyAdapter we need a view holder annotated with a
- * valid layout ID. At te moment it's not possible to define a resource layout in the test variant
- * and didn't want to include resources in the library that are only used for testing.
+ * valid layout ID. At the moment it's not possible to define a resource layout in the test variant
+ * and I didn't want to include resources in the library that are only used for testing.
  */
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -82,6 +82,13 @@ public class EasyAdapterTest {
         assertEquals(person2, mEasyAdapter.getItem(1));
     }
 
+    @Test public void testGetItems() throws Exception {
+        List<Person> list = getSomePeople();
+        EasyAdapter<Person> easyAdapter = new EasyAdapter<>(RuntimeEnvironment.application,
+                PersonViewHolder.class, list);
+        assertEquals(list, easyAdapter.getItems());
+    }
+
     @Test public void testSetItems() throws Exception {
         List<Person> list = getSomePeople();
         assertEquals(0, mEasyAdapter.getItems().size());
@@ -96,13 +103,6 @@ public class EasyAdapterTest {
         mEasyAdapter.setItemsWithoutNotifying(list);
         assertEquals(list, mEasyAdapter.getItems());
         verify(mMockDataSetObserver, never()).onChanged();
-    }
-
-    @Test public void testGetItems() throws Exception {
-        List<Person> list = getSomePeople();
-        EasyAdapter<Person> easyAdapter = new EasyAdapter<>(RuntimeEnvironment.application,
-                PersonViewHolder.class, list);
-        assertEquals(list, easyAdapter.getItems());
     }
 
     @Test public void testAddItem() throws Exception {

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyAdapterTest.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyAdapterTest.java
@@ -1,6 +1,8 @@
 package uk.co.ribot.easyadapterdemo;
 
 import android.database.DataSetObserver;
+import android.view.View;
+import android.widget.TextView;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -17,12 +19,25 @@ import uk.co.ribot.easyadapter.EasyAdapter;
 import uk.co.ribot.easyadapterdemo.util.DefaultConfig;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+/**
+ * This test is in the demo app so it can use the layout resources defined for the PersonViewHolder
+ * Ideally it should be in the library module because is testing the EasyAdapter class.
+ * However in order to create an EasyAdapter we need a view holder annotated with a
+ * valid layout ID. At te moment it's not possible to define a resource layout in the test variant
+ * and didn't want to include resources in the library that are only used for testing.
+ */
+
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK)
+// Needs to include package name in config here because of this issue
+// https://github.com/robolectric/robolectric/issues/1623
+@Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK,
+        packageName = DefaultConfig.PACKAGE_NAME)
 public class EasyAdapterTest {
 
     public EasyAdapter<Person> mEasyAdapter;
@@ -32,6 +47,21 @@ public class EasyAdapterTest {
         mEasyAdapter = new EasyAdapter<>(RuntimeEnvironment.application, PersonViewHolder.class);
         mMockDataSetObserver = mock(DataSetObserver.class);
         mEasyAdapter.registerDataSetObserver(mMockDataSetObserver);
+    }
+
+    @Test public void testGetCount() throws Exception {
+        mEasyAdapter.getItems().addAll(Arrays.asList(
+                createPerson("Person1"),
+                createPerson("Person2")));
+        assertEquals(2, mEasyAdapter.getCount());
+    }
+
+    @Test public void testGetItem() throws Exception {
+        Person person1 = createPerson("Person1");
+        Person person2 = createPerson("Person2");
+        mEasyAdapter.getItems().addAll(Arrays.asList(person1, person2));
+        assertEquals(person1, mEasyAdapter.getItem(0));
+        assertEquals(person2, mEasyAdapter.getItem(1));
     }
 
     @Test public void testSetItems() throws Exception {
@@ -47,6 +77,7 @@ public class EasyAdapterTest {
         assertEquals(0, mEasyAdapter.getItems().size());
         mEasyAdapter.setItemsWithoutNotifying(list);
         assertEquals(list, mEasyAdapter.getItems());
+        verify(mMockDataSetObserver, never()).onChanged();
     }
 
     @Test public void testGetItems() throws Exception {
@@ -63,6 +94,73 @@ public class EasyAdapterTest {
 
         assertTrue(mEasyAdapter.getItems().contains(newPerson));
         verify(mMockDataSetObserver).onChanged();
+    }
+
+    @Test public void testRemoveItem() throws Exception {
+        List<Person> items = getSomeData();
+        Person personToRemove = items.get(0);
+        mEasyAdapter.getItems().addAll(items);
+        boolean result = mEasyAdapter.removeItem(personToRemove);
+
+        assertTrue(result);
+        assertFalse(mEasyAdapter.getItems().contains(personToRemove));
+        verify(mMockDataSetObserver).onChanged();
+    }
+
+    @Test public void testRemoveNonExistingItem() throws Exception {
+        Person person = createPerson("Person1");
+        boolean result = mEasyAdapter.removeItem(person);
+
+        assertFalse(result);
+        verify(mMockDataSetObserver, never()).onChanged();
+    }
+
+    @Test public void testAddItems() throws Exception {
+        Person person1 = createPerson("Person1");
+        Person person2 = createPerson("Person2");
+        Person person3 = createPerson("Person3");
+        mEasyAdapter.getItems().add(person1);
+        boolean result = mEasyAdapter.addItems(Arrays.asList(person2, person3));
+
+        assertTrue(result);
+        assertEquals(3, mEasyAdapter.getCount());
+        assertTrue(mEasyAdapter.getItems().contains(person2));
+        assertTrue(mEasyAdapter.getItems().contains(person3));
+        verify(mMockDataSetObserver).onChanged();
+    }
+
+    @Test public void testRemoveItems() throws Exception {
+        Person person1 = createPerson("Person1");
+        Person person2 = createPerson("Person2");
+        Person person3 = createPerson("Person3");
+        mEasyAdapter.getItems().addAll(Arrays.asList(person1, person2, person3));
+        boolean result = mEasyAdapter.removeItems(Arrays.asList(person1, person3));
+
+        assertTrue(result);
+        assertEquals(1, mEasyAdapter.getCount());
+        assertFalse(mEasyAdapter.getItems().contains(person1));
+        assertTrue(mEasyAdapter.getItems().contains(person2));
+        assertFalse(mEasyAdapter.getItems().contains(person3));
+        verify(mMockDataSetObserver).onChanged();
+    }
+
+    @Test public void testRemoveNonExistingItems() throws Exception {
+        Person person1 = createPerson("Person1");
+        Person person2 = createPerson("Person2");
+        boolean result = mEasyAdapter.removeItems(Arrays.asList(person1, person2));
+
+        assertFalse(result);
+        verify(mMockDataSetObserver, never()).onChanged();
+    }
+
+    @Test public void testGetView() throws Exception {
+        List<Person> listPeople = getSomeData();
+        mEasyAdapter.getItems().addAll(listPeople);
+        for (int position = 0; position < listPeople.size(); position++) {
+            View view = mEasyAdapter.getView(position, null, null);
+            TextView textViewName = (TextView) view.findViewById(R.id.text_view_name);
+            assertEquals(listPeople.get(position).getName(), textViewName.getText().toString());
+        }
     }
 
     private List<Person> getSomeData() {

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyAdapterTest.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyAdapterTest.java
@@ -1,0 +1,78 @@
+package uk.co.ribot.easyadapterdemo;
+
+import android.database.DataSetObserver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import uk.co.ribot.easyadapter.BuildConfig;
+import uk.co.ribot.easyadapter.EasyAdapter;
+import uk.co.ribot.easyadapterdemo.util.DefaultConfig;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK)
+public class EasyAdapterTest {
+
+    public EasyAdapter<Person> mEasyAdapter;
+    public DataSetObserver mMockDataSetObserver;
+
+    @Before public void setUp() {
+        mEasyAdapter = new EasyAdapter<>(RuntimeEnvironment.application, PersonViewHolder.class);
+        mMockDataSetObserver = mock(DataSetObserver.class);
+        mEasyAdapter.registerDataSetObserver(mMockDataSetObserver);
+    }
+
+    @Test public void testSetItems() throws Exception {
+        List<Person> list = getSomeData();
+        assertEquals(0, mEasyAdapter.getItems().size());
+        mEasyAdapter.setItems(list);
+        assertEquals(list, mEasyAdapter.getItems());
+        verify(mMockDataSetObserver).onChanged();
+    }
+
+    @Test public void testSetItemsWithoutNotifying() throws Exception {
+        List<Person> list = getSomeData();
+        assertEquals(0, mEasyAdapter.getItems().size());
+        mEasyAdapter.setItemsWithoutNotifying(list);
+        assertEquals(list, mEasyAdapter.getItems());
+    }
+
+    @Test public void testGetItems() throws Exception {
+        List<Person> list = getSomeData();
+        EasyAdapter<Person> easyAdapter = new EasyAdapter<>(RuntimeEnvironment.application,
+                PersonViewHolder.class, list);
+        assertEquals(list, easyAdapter.getItems());
+    }
+
+    @Test public void testAddItem() throws Exception {
+        mEasyAdapter.getItems().addAll(getSomeData());
+        Person newPerson = createPerson("New Person");
+        mEasyAdapter.addItem(newPerson);
+
+        assertTrue(mEasyAdapter.getItems().contains(newPerson));
+        verify(mMockDataSetObserver).onChanged();
+    }
+
+    private List<Person> getSomeData() {
+        Person person1 = createPerson("John Snow");
+        Person person2 = createPerson("Sam Tarly");
+        return Arrays.asList(person1, person2);
+    }
+
+    private Person createPerson(String name) {
+        return new Person(name, "07888999777", R.drawable.ic_launcher);
+    }
+
+}

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyRecyclerAdapterTest.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyRecyclerAdapterTest.java
@@ -46,8 +46,8 @@ import static uk.co.ribot.easyadapterdemo.util.DataUtil.getSomePeople;
  * This test is in the demo app so it can use the layout resources defined for the PersonViewHolder
  * Ideally it should be in the library module because is testing the EasyRecylerAdapter class.
  * However in order to create an EasyAdapter we need a view holder annotated with a
- * valid layout ID. At te moment it's not possible to define a resource layout in the test variant
- * and didn't want to include resources in the library that are only used for testing.
+ * valid layout ID. At the moment it's not possible to define a resource layout in the test variant
+ * and I didn't want to include resources in the library that are only used for testing.
  */
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -83,6 +83,15 @@ public class EasyRecyclerAdapterTest {
         assertEquals(person2, mEasyRecyclerAdapter.getItem(1));
     }
 
+    @Test public void testGetItems() throws Exception {
+        List<Person> list = getSomePeople();
+        EasyRecyclerAdapter<Person> easyRecyclerAdapter = new EasyRecyclerAdapter<>(
+                RuntimeEnvironment.application,
+                PersonViewHolder.class,
+                list);
+        assertEquals(list, easyRecyclerAdapter.getItems());
+    }
+
     @Test public void testSetItems() throws Exception {
         List<Person> list = getSomePeople();
         assertEquals(0, mEasyRecyclerAdapter.getItems().size());
@@ -97,15 +106,6 @@ public class EasyRecyclerAdapterTest {
         mEasyRecyclerAdapter.setItemsWithoutNotifying(list);
         assertEquals(list, mEasyRecyclerAdapter.getItems());
         verify(mMockAdapterDataObserver, never()).onChanged();
-    }
-
-    @Test public void testGetItems() throws Exception {
-        List<Person> list = getSomePeople();
-        EasyRecyclerAdapter<Person> easyRecyclerAdapter = new EasyRecyclerAdapter<>(
-                RuntimeEnvironment.application,
-                PersonViewHolder.class,
-                list);
-        assertEquals(list, easyRecyclerAdapter.getItems());
     }
 
     @Test public void testAddItem() throws Exception {

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyRecyclerAdapterTest.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/EasyRecyclerAdapterTest.java
@@ -16,9 +16,7 @@
 
 package uk.co.ribot.easyadapterdemo;
 
-import android.database.DataSetObserver;
-import android.view.View;
-import android.widget.TextView;
+import android.support.v7.widget.RecyclerView;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,12 +29,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import uk.co.ribot.easyadapter.BuildConfig;
-import uk.co.ribot.easyadapter.EasyAdapter;
+import uk.co.ribot.easyadapter.EasyRecyclerAdapter;
 import uk.co.ribot.easyadapterdemo.util.DefaultConfig;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,7 +44,7 @@ import static uk.co.ribot.easyadapterdemo.util.DataUtil.getSomePeople;
 
 /**
  * This test is in the demo app so it can use the layout resources defined for the PersonViewHolder
- * Ideally it should be in the library module because is testing the EasyAdapter class.
+ * Ideally it should be in the library module because is testing the EasyRecylerAdapter class.
  * However in order to create an EasyAdapter we need a view holder annotated with a
  * valid layout ID. At te moment it's not possible to define a resource layout in the test variant
  * and didn't want to include resources in the library that are only used for testing.
@@ -56,129 +55,127 @@ import static uk.co.ribot.easyadapterdemo.util.DataUtil.getSomePeople;
 // https://github.com/robolectric/robolectric/issues/1623
 @Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK,
         packageName = DefaultConfig.PACKAGE_NAME)
-public class EasyAdapterTest {
+public class EasyRecyclerAdapterTest {
 
-    public EasyAdapter<Person> mEasyAdapter;
-    public DataSetObserver mMockDataSetObserver;
+    public EasyRecyclerAdapter<Person> mEasyRecyclerAdapter;
+    public RecyclerView.AdapterDataObserver mMockAdapterDataObserver;
 
     @Before public void setUp() {
-        mEasyAdapter = new EasyAdapter<>(RuntimeEnvironment.application, PersonViewHolder.class);
-        mMockDataSetObserver = mock(DataSetObserver.class);
-        mEasyAdapter.registerDataSetObserver(mMockDataSetObserver);
+        mEasyRecyclerAdapter = new EasyRecyclerAdapter<>(
+                RuntimeEnvironment.application,
+                PersonViewHolder.class);
+        mMockAdapterDataObserver = mock(RecyclerView.AdapterDataObserver.class);
+        mEasyRecyclerAdapter.registerAdapterDataObserver(mMockAdapterDataObserver);
     }
 
-    @Test public void testGetCount() throws Exception {
-        mEasyAdapter.getItems().addAll(Arrays.asList(
+    @Test public void testGetItemCount() throws Exception {
+        mEasyRecyclerAdapter.getItems().addAll(Arrays.asList(
                 createPerson("Person1"),
                 createPerson("Person2")));
-        assertEquals(2, mEasyAdapter.getCount());
+        assertEquals(2, mEasyRecyclerAdapter.getItemCount());
     }
 
     @Test public void testGetItem() throws Exception {
         Person person1 = createPerson("Person1");
         Person person2 = createPerson("Person2");
-        mEasyAdapter.getItems().addAll(Arrays.asList(person1, person2));
-        assertEquals(person1, mEasyAdapter.getItem(0));
-        assertEquals(person2, mEasyAdapter.getItem(1));
+        mEasyRecyclerAdapter.getItems().addAll(Arrays.asList(person1, person2));
+        assertEquals(person1, mEasyRecyclerAdapter.getItem(0));
+        assertEquals(person2, mEasyRecyclerAdapter.getItem(1));
     }
 
     @Test public void testSetItems() throws Exception {
         List<Person> list = getSomePeople();
-        assertEquals(0, mEasyAdapter.getItems().size());
-        mEasyAdapter.setItems(list);
-        assertEquals(list, mEasyAdapter.getItems());
-        verify(mMockDataSetObserver).onChanged();
+        assertEquals(0, mEasyRecyclerAdapter.getItems().size());
+        mEasyRecyclerAdapter.setItems(list);
+        assertEquals(list, mEasyRecyclerAdapter.getItems());
+        verify(mMockAdapterDataObserver).onChanged();
     }
 
     @Test public void testSetItemsWithoutNotifying() throws Exception {
         List<Person> list = getSomePeople();
-        assertEquals(0, mEasyAdapter.getItems().size());
-        mEasyAdapter.setItemsWithoutNotifying(list);
-        assertEquals(list, mEasyAdapter.getItems());
-        verify(mMockDataSetObserver, never()).onChanged();
+        assertEquals(0, mEasyRecyclerAdapter.getItems().size());
+        mEasyRecyclerAdapter.setItemsWithoutNotifying(list);
+        assertEquals(list, mEasyRecyclerAdapter.getItems());
+        verify(mMockAdapterDataObserver, never()).onChanged();
     }
 
     @Test public void testGetItems() throws Exception {
         List<Person> list = getSomePeople();
-        EasyAdapter<Person> easyAdapter = new EasyAdapter<>(RuntimeEnvironment.application,
-                PersonViewHolder.class, list);
-        assertEquals(list, easyAdapter.getItems());
+        EasyRecyclerAdapter<Person> easyRecyclerAdapter = new EasyRecyclerAdapter<>(
+                RuntimeEnvironment.application,
+                PersonViewHolder.class,
+                list);
+        assertEquals(list, easyRecyclerAdapter.getItems());
     }
 
     @Test public void testAddItem() throws Exception {
-        mEasyAdapter.getItems().addAll(getSomePeople());
+        mEasyRecyclerAdapter.getItems().addAll(getSomePeople());
         Person newPerson = createPerson("New Person");
-        mEasyAdapter.addItem(newPerson);
+        mEasyRecyclerAdapter.addItem(newPerson);
 
-        assertTrue(mEasyAdapter.getItems().contains(newPerson));
-        verify(mMockDataSetObserver).onChanged();
+        int indexOfItem = mEasyRecyclerAdapter.getItems().indexOf(newPerson);
+        assertTrue(indexOfItem > 0);
+        verify(mMockAdapterDataObserver).onItemRangeInserted(indexOfItem, 1);
     }
 
     @Test public void testRemoveItem() throws Exception {
         List<Person> items = getSomePeople();
         Person personToRemove = items.get(0);
-        mEasyAdapter.getItems().addAll(items);
-        boolean result = mEasyAdapter.removeItem(personToRemove);
+        mEasyRecyclerAdapter.getItems().addAll(items);
+        boolean result = mEasyRecyclerAdapter.removeItem(personToRemove);
 
         assertTrue(result);
-        assertFalse(mEasyAdapter.getItems().contains(personToRemove));
-        verify(mMockDataSetObserver).onChanged();
+        assertFalse(mEasyRecyclerAdapter.getItems().contains(personToRemove));
+        verify(mMockAdapterDataObserver).onItemRangeRemoved(0, 1);
     }
 
     @Test public void testRemoveNonExistingItem() throws Exception {
         Person person = createPerson("Person1");
-        boolean result = mEasyAdapter.removeItem(person);
+        boolean result = mEasyRecyclerAdapter.removeItem(person);
 
         assertFalse(result);
-        verify(mMockDataSetObserver, never()).onChanged();
+        verify(mMockAdapterDataObserver, never()).onChanged();
+        verify(mMockAdapterDataObserver, never()).onItemRangeRemoved(anyInt(), anyInt());
     }
 
     @Test public void testAddItems() throws Exception {
         Person person1 = createPerson("Person1");
         Person person2 = createPerson("Person2");
         Person person3 = createPerson("Person3");
-        mEasyAdapter.getItems().add(person1);
-        boolean result = mEasyAdapter.addItems(Arrays.asList(person2, person3));
+        mEasyRecyclerAdapter.getItems().add(person1);
+        List<Person> listToAdd = Arrays.asList(person2, person3);
+        boolean result = mEasyRecyclerAdapter.addItems(listToAdd);
 
         assertTrue(result);
-        assertEquals(3, mEasyAdapter.getCount());
-        assertTrue(mEasyAdapter.getItems().contains(person2));
-        assertTrue(mEasyAdapter.getItems().contains(person3));
-        verify(mMockDataSetObserver).onChanged();
+        assertEquals(3, mEasyRecyclerAdapter.getItemCount());
+        assertTrue(mEasyRecyclerAdapter.getItems().contains(person2));
+        assertTrue(mEasyRecyclerAdapter.getItems().contains(person3));
+        verify(mMockAdapterDataObserver).onItemRangeInserted(1, listToAdd.size());
     }
 
     @Test public void testRemoveItems() throws Exception {
         Person person1 = createPerson("Person1");
         Person person2 = createPerson("Person2");
         Person person3 = createPerson("Person3");
-        mEasyAdapter.getItems().addAll(Arrays.asList(person1, person2, person3));
-        boolean result = mEasyAdapter.removeItems(Arrays.asList(person1, person3));
+        mEasyRecyclerAdapter.getItems().addAll(Arrays.asList(person1, person2, person3));
+        boolean result = mEasyRecyclerAdapter.removeItems(Arrays.asList(person1, person3));
 
         assertTrue(result);
-        assertEquals(1, mEasyAdapter.getCount());
-        assertFalse(mEasyAdapter.getItems().contains(person1));
-        assertTrue(mEasyAdapter.getItems().contains(person2));
-        assertFalse(mEasyAdapter.getItems().contains(person3));
-        verify(mMockDataSetObserver).onChanged();
+        assertEquals(1, mEasyRecyclerAdapter.getItemCount());
+        assertFalse(mEasyRecyclerAdapter.getItems().contains(person1));
+        assertTrue(mEasyRecyclerAdapter.getItems().contains(person2));
+        assertFalse(mEasyRecyclerAdapter.getItems().contains(person3));
+        verify(mMockAdapterDataObserver).onChanged();
     }
 
     @Test public void testRemoveNonExistingItems() throws Exception {
         Person person1 = createPerson("Person1");
         Person person2 = createPerson("Person2");
-        boolean result = mEasyAdapter.removeItems(Arrays.asList(person1, person2));
+        boolean result = mEasyRecyclerAdapter.removeItems(Arrays.asList(person1, person2));
 
         assertFalse(result);
-        verify(mMockDataSetObserver, never()).onChanged();
-    }
-
-    @Test public void testGetView() throws Exception {
-        List<Person> listPeople = getSomePeople();
-        mEasyAdapter.getItems().addAll(listPeople);
-        for (int position = 0; position < listPeople.size(); position++) {
-            View view = mEasyAdapter.getView(position, null, null);
-            TextView textViewName = (TextView) view.findViewById(R.id.text_view_name);
-            assertEquals(listPeople.get(position).getName(), textViewName.getText().toString());
-        }
+        verify(mMockAdapterDataObserver, never()).onChanged();
+        verify(mMockAdapterDataObserver, never()).onItemRangeRemoved(anyInt(), anyInt());
     }
 
 }

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DataUtil.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DataUtil.java
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
-package uk.co.ribot.easyadapter.util;
+package uk.co.ribot.easyadapterdemo.util;
 
-public class DefaultConfig {
-    //The api level that Robolectric will use to run the unit tests
-    public static final int EMULATE_SDK = 21;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.co.ribot.easyadapterdemo.Person;
+import uk.co.ribot.easyadapterdemo.R;
+
+public final class DataUtil {
+
+    public static List<Person> getSomePeople() {
+        Person person1 = createPerson("John Snow");
+        Person person2 = createPerson("Sam Tarly");
+        return Arrays.asList(person1, person2);
+    }
+
+    public static Person createPerson(String name) {
+        return new Person(name, "07888999777", R.drawable.ic_launcher);
+    }
 }

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DefaultConfig.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DefaultConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2015 Ribot Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.co.ribot.easyadapterdemo.util;
 
 public class DefaultConfig {

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DefaultConfig.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DefaultConfig.java
@@ -3,4 +3,5 @@ package uk.co.ribot.easyadapterdemo.util;
 public class DefaultConfig {
     //The api level that Robolectric will use to run the unit tests
     public static final int EMULATE_SDK = 21;
+    public static final String PACKAGE_NAME = "uk.co.ribot.easyadapterdemo";
 }

--- a/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DefaultConfig.java
+++ b/demo/src/test/java/uk/co/ribot/easyadapterdemo/util/DefaultConfig.java
@@ -1,0 +1,6 @@
+package uk.co.ribot.easyadapterdemo.util;
+
+public class DefaultConfig {
+    //The api level that Robolectric will use to run the unit tests
+    public static final int EMULATE_SDK = 21;
+}

--- a/library/src/main/java/uk/co/ribot/easyadapter/EasyAdapter.java
+++ b/library/src/main/java/uk/co/ribot/easyadapter/EasyAdapter.java
@@ -90,7 +90,7 @@ public class EasyAdapter<T> extends BaseEasyAdapter<T> {
      * Use {@link #setItemsWithoutNotifying(List)}()} if you don't want to refresh
      * the {@code AdapterView} at this time.
      *
-     * @param listItems  new List of items to use as the underlying data structure
+     * @param listItems new List of items to use as the underlying data structure
      */
     public void setItems(List<T> listItems) {
         mListItems = listItems;

--- a/library/src/main/java/uk/co/ribot/easyadapter/EasyAdapter.java
+++ b/library/src/main/java/uk/co/ribot/easyadapter/EasyAdapter.java
@@ -88,7 +88,7 @@ public class EasyAdapter<T> extends BaseEasyAdapter<T> {
      * Set a new list of items into the Adapter and refresh the {@code AdapterView} by calling
      * {@code notifyDataSetChanged()}.
      * Use {@link #setItemsWithoutNotifying(List)}()} if you don't want to refresh
-     * the {@code }AdapterView} at this time.
+     * the {@code AdapterView} at this time.
      *
      * @param listItems  new List of items to use as the underlying data structure
      */

--- a/library/src/main/java/uk/co/ribot/easyadapter/EasyAdapter.java
+++ b/library/src/main/java/uk/co/ribot/easyadapter/EasyAdapter.java
@@ -18,6 +18,7 @@ package uk.co.ribot.easyadapter;
 import android.content.Context;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -80,13 +81,16 @@ public class EasyAdapter<T> extends BaseEasyAdapter<T> {
      */
     public EasyAdapter(Context context, Class<? extends ItemViewHolder> itemViewHolderClass, Object listener) {
         super(context, itemViewHolderClass, listener);
-        mListItems = new ArrayList<T>();
+        mListItems = new ArrayList<>();
     }
 
     /**
-     * Sets a new list of items into the Adapter
+     * Set a new list of items into the Adapter and refresh the {@code AdapterView} by calling
+     * {@code notifyDataSetChanged()}.
+     * Use {@link #setItemsWithoutNotifying(List)}()} if you don't want to refresh
+     * the {@code }AdapterView} at this time.
      *
-     * @param listItems new list of items
+     * @param listItems  new List of items to use as the underlying data structure
      */
     public void setItems(List<T> listItems) {
         mListItems = listItems;
@@ -94,7 +98,27 @@ public class EasyAdapter<T> extends BaseEasyAdapter<T> {
     }
 
     /**
-     * Adds a single item to the Adapter
+     * Set a new list of items into the Adapter.
+     *
+     * @param listItems new List of items to use as the underlying data structure
+     */
+    public void setItemsWithoutNotifying(List<T> listItems) {
+        mListItems = listItems;
+    }
+
+    /**
+     * Retrieve the {@code List} of items. Changes to this {@code List} directly affect the data displayed on
+     * the {@code AdapterView}.
+     *
+     * @return the underlying data {@code List}
+     */
+    public List<T> getItems() {
+        return mListItems;
+    }
+
+    /**
+     * Add a single item and refresh the {@code AdapterView} by calling
+     * {@code notifyDataSetChanged()}.
      *
      * @param item item to add
      */
@@ -104,13 +128,48 @@ public class EasyAdapter<T> extends BaseEasyAdapter<T> {
     }
 
     /**
-     * Appends a list of items to the ones already in the Adapter
+     * Remove a single item and refresh the {@code AdapterView} by calling
+     * {@code notifyDataSetChanged()}.
      *
-     * @param listItems list of items to append
+     * @param item item to add
+     * @return true if any data was modified by this operation, false otherwise.
      */
-    public void addItems(List<T> listItems) {
-        mListItems.addAll(listItems);
-        notifyDataSetChanged();
+    public boolean removeItem(T item) {
+        if (mListItems.remove(item)) {
+            notifyDataSetChanged();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Append a collection of items and refresh the {@code AdapterView} by calling
+     * {@code notifyDataSetChanged()}.
+     *
+     * @param items collection of items to append
+     * @return true if any data was modified by this operation, false otherwise.
+     */
+    public boolean addItems(Collection<? extends T> items) {
+        if (mListItems.addAll(items)) {
+            notifyDataSetChanged();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Remove a collection of items and refresh the {@code AdapterView} by calling
+     * {@code notifyDataSetChanged()}.
+     *
+     * @param items {@code Collection} of items to remove
+     * @return true if any data was modified by this operation, false otherwise.
+     */
+    public boolean removeItems(Collection<? extends T> items) {
+        if (mListItems.removeAll(items)) {
+            notifyDataSetChanged();
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/library/src/main/java/uk/co/ribot/easyadapter/EasyRecyclerAdapter.java
+++ b/library/src/main/java/uk/co/ribot/easyadapter/EasyRecyclerAdapter.java
@@ -118,7 +118,6 @@ public class EasyRecyclerAdapter<T> extends BaseEasyRecyclerAdapter<T> {
         return mListItems;
     }
 
-
     /**
      * Add a single item and refresh the {@code RecyclerView} by calling
      * {@code notifyItemInserted()}.

--- a/library/src/main/java/uk/co/ribot/easyadapter/EasyRecyclerAdapter.java
+++ b/library/src/main/java/uk/co/ribot/easyadapter/EasyRecyclerAdapter.java
@@ -152,7 +152,7 @@ public class EasyRecyclerAdapter<T> extends BaseEasyRecyclerAdapter<T> {
      * @return true if any data was modified by this operation, false otherwise.
      */
     public boolean addItems(Collection<T> items) {
-        if (items.size() == 0) return false;
+        if (items.isEmpty()) return false;
         int previousSize = getItemCount();
         if (mListItems.addAll(items)) {
             notifyItemRangeInserted(previousSize, items.size());

--- a/library/src/main/java/uk/co/ribot/easyadapter/EasyRecyclerAdapter.java
+++ b/library/src/main/java/uk/co/ribot/easyadapter/EasyRecyclerAdapter.java
@@ -19,6 +19,7 @@ package uk.co.ribot.easyadapter;
 import android.content.Context;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -86,9 +87,12 @@ public class EasyRecyclerAdapter<T> extends BaseEasyRecyclerAdapter<T> {
     }
 
     /**
-     * Sets a new list of items into the Adapter
+     * Set a new list of items into the Adapter and refresh the {@code RecyclerView} by calling
+     * {@code notifyDataSetChanged()}.
+     * Use {@link #setItemsWithoutNotifying(List)}()} if you don't want to refresh
+     * the {@code RecyclerView} at this time.
      *
-     * @param listItems new list of items
+     * @param listItems new List of items to use as the underlying data structure
      */
     public void setItems(List<T> listItems) {
         mListItems = listItems;
@@ -96,7 +100,28 @@ public class EasyRecyclerAdapter<T> extends BaseEasyRecyclerAdapter<T> {
     }
 
     /**
-     * Adds a single item to the Adapter
+     * Set a new list of items into the Adapter.
+     *
+     * @param listItems new List of items to use as the underlying data structure
+     */
+    public void setItemsWithoutNotifying(List<T> listItems) {
+        mListItems = listItems;
+    }
+
+    /**
+     * Retrieve the {@code List} of items. Changes to this {@code List} directly affect the data displayed on
+     * the {@code RecyclerView}.
+     *
+     * @return the underlying data {@code List}
+     */
+    public List<T> getItems() {
+        return mListItems;
+    }
+
+
+    /**
+     * Add a single item and refresh the {@code RecyclerView} by calling
+     * {@code notifyItemInserted()}.
      *
      * @param item item to add
      */
@@ -106,14 +131,50 @@ public class EasyRecyclerAdapter<T> extends BaseEasyRecyclerAdapter<T> {
     }
 
     /**
-     * Appends a list of items to the ones already in the Adapter
+     * Remove a single item and refresh the {@code RecyclerView} by calling
+     * {@code notifyItemRemoved()}.
      *
-     * @param listItems list of items to append
+     * @param item item to add
+     * @return true if any data was modified by this operation, false otherwise.
      */
-    public void addItems(List<T> listItems) {
-        if (listItems.size() == 0) return;
-        mListItems.addAll(listItems);
-        notifyItemRangeInserted(mListItems.indexOf(listItems.get(0)), listItems.size());
+    public boolean removeItem(T item) {
+        int index = mListItems.indexOf(item);
+        if (index < 0) return false;
+        mListItems.remove(index);
+        notifyItemRemoved(index);
+        return true;
+    }
+
+    /**
+     * Append a collection of items and refresh the {@code RecyclerView} by calling
+     * {@code notifyItemRangeInserted()}.
+     *
+     * @param items collection of items to append
+     * @return true if any data was modified by this operation, false otherwise.
+     */
+    public boolean addItems(Collection<T> items) {
+        if (items.size() == 0) return false;
+        int previousSize = getItemCount();
+        if (mListItems.addAll(items)) {
+            notifyItemRangeInserted(previousSize, items.size());
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Remove a collection of items and refresh the {@code RecyclerView} by calling
+     * {@code notifyDataSetChanged()}.
+     *
+     * @param items {@code Collection} of items to remove
+     * @return true if any data was modified by this operation, false otherwise.
+     */
+    public boolean removeItems(Collection<? extends T> items) {
+        if (mListItems.removeAll(items)) {
+            notifyDataSetChanged();
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Add extra methods to `EasyAdapter` and `EasyRecyclerAdapter`:

* `getItems()`: will return the underlying `List` of data items so provides more flexibility to interact with the Adapter. 
* `removeItem(T item)`: Removes a given item from the adapter and refreshes the `AdapterView` or `RecyclerView`
* `removeItems(Collection items)`: Same as above but for a collection of items. 
* `addItems(Collection items)`: Add a collection of items and refreshes the `AdapterView` or `RecyclerView`
* `setItemsWithoutNotifying(List)`: same as `setItems(List)` but this method does not call `notifyDataSetChanged()`

Also add unit tests for all the methods in `EasyAdapter` and `EasyRecyclerAdapter`. 
