### PR TITLE
The cache of Travis CI can improve build performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ env:
         # Using the new Container-Based Infrastructure
         - sudo: false
         # Turning off caching to avoid caching Issues
-        - cache: false
+        - cache:
+            directories:
+            - $HOME/.gradle/caches/
+            - $HOME/.gradle/wrapper/
         # Initiating clean Gradle output
         - TERM=dumb
         # Giving even more memory to Gradle JVM


### PR DESCRIPTION
[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.
